### PR TITLE
last_started_alert: require multiple consecutive failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ install:
   - pip install pipenv
   - cd worker_health
   - pipenv install --dev
+  - cd ..
 
 script:
+  # worker_health
+  - cd worker_health
   - pyflakes *.py
   - pytest -v
   - ./test_help.sh
+  - cd ..
+  # devicepool_last_started_alert
+  - cd devicepool_last_started_alert
+  - pyflakes *.py

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -291,6 +291,8 @@ current_dedup_key = ""
             # alert decision logic
             triggered_now = False
             if jobs_in_queues > 5:
+                # TODO: also ensure that there are no jobs running before alerting?
+                #   - would reduce false alerts...
                 if not started_lines_present:
                     triggered_now = True
 

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -194,7 +194,8 @@ class LastStarted:
         return False
 
     def running_lines_present(self, output):
-        for line in output:
+        lines = output.split("\n")
+        for line in lines:
             matches = re.search(RUNNING_REGEX, line)
             if matches:
                 count = matches.group(1)

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -259,7 +259,7 @@ current_dedup_key = ""
         # TODO: make this set an instance var, default functions to use it
         output = self.get_journalctl_output()
         currently_alerting = self.currently_alerting()
-        jobs_in_queues = self.jobs_in_queues(output)
+        jobs_in_queues = self.jobs_in_queues()
         started_lines_present = self.started_lines_present(output)
         running_lines_present = self.running_lines_present(output)
         enough_journalctl_lines = self.enough_journalctl_lines()

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -20,6 +20,7 @@ from pdpyras import EventsAPISession
 MINUTES_OF_LOGS_TO_INSPECT = 15
 MINIMUM_LINES_OF_JOURNALCTL_OUTPUT = 10
 DAEMON_MODE_CHECK_FREQUENCY_SECONDS = 5 * 60
+# TODO: load this from config file
 PD_SERVICE_ID = "PAYN6NV"
 
 # constants

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -287,17 +287,27 @@ current_dedup_key = ""
             consecutive_failed_checks_to_alert_at = 2
             if triggered_now:
                 self.consecutive_failed_checks += 1
-                if self.consecutive_failed_checks >= consecutive_failed_checks_to_alert_at:
-                    print("*** Alert conditions met (%s consecutive failed checks)! Sending trigger event." % self.consecutive_failed_checks)
+                if (
+                    self.consecutive_failed_checks
+                    >= consecutive_failed_checks_to_alert_at
+                ):
+                    print(
+                        "*** Alert conditions met (%s consecutive failed checks)! Sending trigger event."
+                        % self.consecutive_failed_checks
+                    )
                     self.trigger_event()
                 else:
-                    print("*** Alert conditions met, but threshold not met (%s/%s consecutive failed checks)." % (self.consecutive_failed_checks, consecutive_failed_checks_to_alert_at))
+                    print(
+                        "*** Alert conditions met, but threshold not met (%s/%s consecutive failed checks)."
+                        % (
+                            self.consecutive_failed_checks,
+                            consecutive_failed_checks_to_alert_at,
+                        )
+                    )
             else:
                 self.consecutive_failed_checks = 0
                 if currently_alerting:
-                    print(
-                        "*** Alert conditions not met. Resolving current incident."
-                    )
+                    print("*** Alert conditions not met. Resolving current incident.")
                     self.resolve_incident()
                 else:
                     print("*** Alert conditions not met.")

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -261,7 +261,7 @@ current_dedup_key = ""
         currently_alerting = self.currently_alerting(output)
         jobs_in_queues = self.jobs_in_queues(output)
         started_lines_present = self.started_lines_present(output)
-        # completed_lines_present = self.completed_lines_present()
+        running_lines_present = self.running_lines_present(output)
         enough_journalctl_lines = self.enough_journalctl_lines()
 
         # INFO
@@ -277,7 +277,7 @@ current_dedup_key = ""
                 print(
                     "  Enough lines of journalctl output?: %s" % enough_journalctl_lines
                 )
-                # print("  Completed lines present?: %s" % completed_lines_present)
+                print("  Running lines present?: %s" % running_lines_present)
             print("Decision metrics:")
             print("  Jobs in queues: %s" % jobs_in_queues)
             print("  Started lines present?: %s" % started_lines_present)

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -9,7 +9,6 @@ import pprint
 import re
 import socket
 import subprocess
-import sys
 import time
 from urllib.request import urlopen
 

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -249,7 +249,7 @@ current_dedup_key = ""
         currently_alerting = self.currently_alerting()
         jobs_in_queues = self.jobs_in_queues()
         started_lines_present = self.started_lines_present()
-        completed_lines_present = self.completed_lines_present()
+        # completed_lines_present = self.completed_lines_present()
         enough_journalctl_lines = self.enough_journalctl_lines()
 
         # INFO
@@ -265,7 +265,7 @@ current_dedup_key = ""
                 print(
                     "  Enough lines of journalctl output?: %s" % enough_journalctl_lines
                 )
-                print("  Completed lines present?: %s" % completed_lines_present)
+                # print("  Completed lines present?: %s" % completed_lines_present)
             print("Decision metrics:")
             print("  Jobs in queues: %s" % jobs_in_queues)
             print("  Started lines present?: %s" % started_lines_present)

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -198,7 +198,7 @@ class LastStarted:
             matches = re.search(RUNNING_REGEX, line)
             if matches:
                 count = matches.group(1)
-                if count != 0:
+                if int(count) != 0:
                     return True
         return False
 

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -28,7 +28,7 @@ STATE_FILE = os.path.join(os.path.expanduser("~"), ".last_started_alert_state.to
 INCIDENT_KEY = "Devicepool Last Started Alert: "
 STARTED_REGEX = r"test run [\d]+ started"
 FINISHED_REGEX = r"test run [\d]+ finished"
-RUNNING_REGEX = r"RUNNING (\d+)"
+RUNNING_REGEX = r"DISABLED \d+ RUNNING (\d+)"
 URLS = [
     #    "https://queue.taskcluster.net/v1/pending/proj-autophone/gecko-t-ap-unit-p2",
     #    "https://queue.taskcluster.net/v1/pending/proj-autophone/gecko-t-ap-perf-p2",

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -208,12 +208,7 @@ class LastStarted:
         cmd = (
             "journalctl -u bitbar --since '%s minutes ago'" % MINUTES_OF_LOGS_TO_INSPECT
         )
-        try:
-            res = self.run_cmd(cmd)
-        except subprocess.TimeoutExpired:
-            # just try again for now... should work this time
-            # if not, explode and let systemd restart
-            res = self.run_cmd(cmd)
+        res = self.run_cmd(cmd)
 
         lines = res.split("\n")
         self.journalctl_lines_of_output = len(lines)
@@ -221,14 +216,10 @@ class LastStarted:
         return res
 
     def run_cmd(self, cmd):
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        proc.wait(timeout=10)
-        rc = proc.returncode
-        if rc == 0:
-            tmp = proc.stdout.read().strip()
-            return tmp.decode()
-        else:
-            raise Exception("non-zero code returned")
+        return subprocess.check_output(
+                    cmd,
+                    stderr=subprocess.STDOUT,
+                    shell=True).strip().decode()
 
     def write_toml(self, dict_to_write):
         with open(STATE_FILE, "w") as writer:

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -258,7 +258,7 @@ current_dedup_key = ""
     def perform_check(self, args):
         # TODO: make this set an instance var, default functions to use it
         output = self.get_journalctl_output()
-        currently_alerting = self.currently_alerting(output)
+        currently_alerting = self.currently_alerting()
         jobs_in_queues = self.jobs_in_queues(output)
         started_lines_present = self.started_lines_present(output)
         running_lines_present = self.running_lines_present(output)

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -283,7 +283,7 @@ current_dedup_key = ""
                 if not started_lines_present:
                     triggered_now = True
 
-            consecutive_failed_checks_to_alert_at = 2
+            consecutive_failed_checks_to_alert_at = 3
             if triggered_now:
                 self.consecutive_failed_checks += 1
                 if (


### PR DESCRIPTION
Also:
  - disable tracking of completed lines (devicepool doesn't emit them any longer)
  - add display of if there are running jobs