### PR TITLE
don't report workers with no start time as missing

### DIFF
--- a/worker_health/worker_health.py
+++ b/worker_health/worker_health.py
@@ -377,6 +377,9 @@ class WorkerHealth:
                 if worker in self.tc_current_worker_last_started:
                     # new workers
                     if self.tc_current_worker_last_started[worker] == None:
+                        # TODO: track these in a new datastructure
+                        #   - not a 'problem worker' per se
+                        #     - shouldn't alert partners or logging, but good to know
                         continue
                     # tardy workers
                     if queue_empty:

--- a/worker_health/worker_health.py
+++ b/worker_health/worker_health.py
@@ -246,12 +246,18 @@ class WorkerHealth:
                 strange_result = True
                 try:
                     if "status" in json_result2:
+                        # test pool workers, new workers
+                        # - workers that just started won't have a 'started'
+                        strange_result = False
+                        self.tc_current_worker_last_started[
+                                worker["workerId"]
+                            ] = None
+                        # set started_time if data
                         if "started" in json_result2["status"]["runs"][-1]:
                             started_time = json_result2["status"]["runs"][-1]["started"]
                             self.tc_current_worker_last_started[
                                 worker["workerId"]
                             ] = started_time
-                            strange_result = False
                 except KeyError:
                     # pass, because we mention the strange result below
                     pass
@@ -369,6 +375,9 @@ class WorkerHealth:
                     continue
 
                 if worker in self.tc_current_worker_last_started:
+                    # new workers
+                    if self.tc_current_worker_last_started[worker] == None:
+                        continue
                     # tardy workers
                     if queue_empty:
                         continue
@@ -384,12 +393,11 @@ class WorkerHealth:
                             continue
                         mw2[queue].append(worker)
                 else:
-                    # fully missing worker
                     if queue_empty:
                         continue
                     if more_workers_than_jobs:
                         continue
-                    # will we ever reach this?
+                    # fully missing worker
                     mw2[queue].append(worker)
         return mw2
 

--- a/worker_health/worker_health.py
+++ b/worker_health/worker_health.py
@@ -381,11 +381,11 @@ class WorkerHealth:
                         #   - not a 'problem worker' per se
                         #     - shouldn't alert partners or logging, but good to know
                         continue
-                    # tardy workers
                     if queue_empty:
                         continue
                     if more_workers_than_jobs:
                         continue
+                    # tardy workers
                     now_dt = pendulum.now(tz="UTC")
                     last_started_dt = pendulum.parse(
                         self.tc_current_worker_last_started[worker]

--- a/worker_health/worker_health.py
+++ b/worker_health/worker_health.py
@@ -252,7 +252,8 @@ class WorkerHealth:
                         self.tc_current_worker_last_started[
                                 worker["workerId"]
                             ] = None
-                        # set started_time if data
+                        # normal workers
+                        # - set started_time if data
                         if "started" in json_result2["status"]["runs"][-1]:
                             started_time = json_result2["status"]["runs"][-1]["started"]
                             self.tc_current_worker_last_started[

--- a/worker_health/worker_health.py
+++ b/worker_health/worker_health.py
@@ -246,19 +246,20 @@ class WorkerHealth:
                 strange_result = True
                 try:
                     if "status" in json_result2:
-                        # test pool workers, new workers
-                        # - workers that just started won't have a 'started'
-                        strange_result = False
-                        self.tc_current_worker_last_started[
-                                worker["workerId"]
-                            ] = None
-                        # normal workers
-                        # - set started_time if data
-                        if "started" in json_result2["status"]["runs"][-1]:
-                            started_time = json_result2["status"]["runs"][-1]["started"]
+                        if 'runs' in json_result2["status"]:
+                            # test pool workers, new workers
+                            # - workers that just started won't have a 'started'
+                            strange_result = False
                             self.tc_current_worker_last_started[
-                                worker["workerId"]
-                            ] = started_time
+                                    worker["workerId"]
+                                ] = None
+                            # normal workers
+                            # - set started_time if data
+                            if "started" in json_result2["status"]["runs"][-1]:
+                                started_time = json_result2["status"]["runs"][-1]["started"]
+                                self.tc_current_worker_last_started[
+                                    worker["workerId"]
+                                ] = started_time
                 except KeyError:
                     # pass, because we mention the strange result below
                     pass


### PR DESCRIPTION
Test workers aren't missing, they just don't have a started time if there are issues with the image.

Also:
  - comment tweaks/cleanup