### PR TITLE
last started: catch exceptions

### DIFF
--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -342,4 +342,4 @@ if __name__ == "__main__":
         try:
             ls.perform_check(args)
         except Exception as e:
-            print("exception received: %s" % e)
+            print("Exception received (%s), continuing..." % e)

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -339,10 +339,10 @@ if __name__ == "__main__":
             try:
                 ls.perform_check(args)
             except Exception as e:
-                print("Exception received (%s), continuing..." % e)
+                print("Exception received (%s:  %s), continuing..." % (type(e), e))
             time.sleep(DAEMON_MODE_CHECK_FREQUENCY_SECONDS)
     else:
         try:
             ls.perform_check(args)
         except Exception as e:
-            print("Exception received (%s), exiting..." % e)
+            print("Exception received (%s:  %s), exiting..." % (type(e), e))

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -44,6 +44,11 @@ class LastStartedException(Exception):
     pass
 
 
+# TODO: why does this inherit?
+class LastStartedFetchException(LastStartedException):
+    pass
+
+
 class LastStarted:
     def __init__(self):
         self.alerting_enabled = False
@@ -86,20 +91,20 @@ class LastStarted:
             data = urlopen(url).read()
             output = json.loads(data)
         except HTTPError:
-            print("HTTPError when fetching '%s'. Continuing..." % url)
-            output = ""
+            raise LastStartedFetchException(
+                "HTTPError when fetching '%s'. Continuing..." % url
+            )
         return output
 
     def jobs_in_queues(self):
         count = 0
         for url in URLS:
             json_result = self.get_url(url)
-            # print(json_result)
             try:
                 count += json_result["pendingTasks"]
             except TypeError:
                 raise LastStartedException(
-                    "data fetching error detected. received: '%s'" % json_result
+                    "data formatting error detected. received: '%s'" % json_result
                 )
         return count
 

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -11,7 +11,6 @@ import socket
 import subprocess
 import time
 from urllib.request import urlopen
-from urllib.error import HTTPError
 
 import toml
 from pdpyras import EventsAPISession
@@ -38,15 +37,6 @@ URLS = [
     "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/proj-autophone/gecko-t-bitbar-gw-perf-g5",
     "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/proj-autophone/gecko-t-bitbar-gw-unit-g5",
 ]
-
-
-class LastStartedException(Exception):
-    pass
-
-
-# TODO: why does this inherit?
-class LastStartedFetchException(LastStartedException):
-    pass
 
 
 class LastStarted:
@@ -87,25 +77,15 @@ class LastStarted:
         sess.log.setLevel(logging.DEBUG)
 
     def get_url(self, url):
-        try:
-            data = urlopen(url).read()
-            output = json.loads(data)
-        except HTTPError:
-            raise LastStartedFetchException(
-                "HTTPError when fetching '%s'. Continuing..." % url
-            )
+        data = urlopen(url).read()
+        output = json.loads(data)
         return output
 
     def jobs_in_queues(self):
         count = 0
         for url in URLS:
             json_result = self.get_url(url)
-            try:
-                count += json_result["pendingTasks"]
-            except TypeError:
-                raise LastStartedException(
-                    "data formatting error detected. received: '%s'" % json_result
-                )
+            count += json_result["pendingTasks"]
         return count
 
     # code for querying incidents

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -336,7 +336,10 @@ if __name__ == "__main__":
             % DAEMON_MODE_CHECK_FREQUENCY_SECONDS
         )
         while True:
-            ls.perform_check(args)
+            try:
+                ls.perform_check(args)
+            except Exception as e:
+                print("Exception received (%s), continuing..." % e)
             time.sleep(DAEMON_MODE_CHECK_FREQUENCY_SECONDS)
     else:
         try:

--- a/devicepool_last_started_alert/last_started_alert.py
+++ b/devicepool_last_started_alert/last_started_alert.py
@@ -345,4 +345,4 @@ if __name__ == "__main__":
         try:
             ls.perform_check(args)
         except Exception as e:
-            print("Exception received (%s), continuing..." % e)
+            print("Exception received (%s), exiting..." % e)


### PR DESCRIPTION
Seen in the wild... 

```
Dec 10 14:33:15 bitbar-devicepool-0 systemd[1]: Started devicepool monitoring service.
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: Alerting is enabled.
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: Minutes of logs to inspect: 15
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: Daemon mode activated. Will perform checks every 300 seconds.
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: HTTPError when fetching 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/proj-autophone/gecko-t-bitbar-gw-batt-p2'. Continuing...
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: Traceback (most recent call last):
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:   File "/home/bitbar/android-tools/devicepool_last_started_alert/last_started_alert.py", line 345, in <module>
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:     ls.perform_check(args)
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:   File "/home/bitbar/android-tools/devicepool_last_started_alert/last_started_alert.py", line 252, in perform_check
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:     jobs_in_queues = self.jobs_in_queues()
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:   File "/home/bitbar/android-tools/devicepool_last_started_alert/last_started_alert.py", line 94, in jobs_in_queues
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]:     count += json_result["pendingTasks"]
Dec 10 14:33:16 bitbar-devicepool-0 python[5321]: TypeError: string indices must be integers
```