### PR TITLE
missing_workers: a51 support

### DIFF
--- a/worker_health/worker_health/worker_health.py
+++ b/worker_health/worker_health/worker_health.py
@@ -670,6 +670,7 @@ class WorkerHealth:
             if (
                 item.startswith("motog5")
                 or item.startswith("pixel2")
+                or item.startswith("a51")
                 or item.startswith("s7")
                 or item.startswith("test")
             ):


### PR DESCRIPTION
Noticed a51 devices weren't appearing in missing_workers output.