### PR TITLE
safe_runner: don't explode on expired jobs

### DIFF
--- a/worker_health/worker_health/status.py
+++ b/worker_health/worker_health/status.py
@@ -26,9 +26,7 @@ class Status:
             data = json.load(json_file)
         creds = {"clientId": data["clientId"], "accessToken": data["accessToken"]}
 
-        self.tc_wm = taskcluster.WorkerManager(
-            {"rootUrl": self.root_url, "credentials": creds}
-        )
+        self.tc_wm = taskcluster.WorkerManager({"rootUrl": self.root_url, "credentials": creds})
         self.tc_h = tc_helpers.TCHelper(provisioner=self.provisioner)
 
     def wait_until_no_jobs_running(self, hosts, sleep_seconds=15, show_indicator=True):
@@ -54,9 +52,7 @@ class Status:
         while True:
             if show_indicator:
                 print(".", end="", flush=True)
-            hosts_with_non_completed_or_failed_jobs_set = set(
-                self.get_hosts_running_jobs(hosts)
-            )
+            hosts_with_non_completed_or_failed_jobs_set = set(self.get_hosts_running_jobs(hosts))
             hosts_idle = hosts_set - hosts_with_non_completed_or_failed_jobs_set
             if hosts_idle:
                 if show_indicator:
@@ -81,12 +77,12 @@ class Status:
                 # pprint.pprint(task_id)
                 _tid, status_blob, _exc = self.tc_h.get_task_status(task_id)
                 # pprint.pprint(status_blob)
-                t_status = status_blob["status"]["state"]
-                if (
-                    t_status != "completed"
-                    and t_status != "failed"
-                    and t_status != "exception"
-                ):
+                try:
+                    t_status = status_blob["status"]["state"]
+                except KeyError:
+                    # print(f"{task_id}: no task[status][state] assuming task is not running.")
+                    continue
+                if t_status != "completed" and t_status != "failed" and t_status != "exception":
                     # TODO: show task id and state if in verbose?
                     # pprint.pprint(status_blob["status"]["state"])
                     hosts_with_non_completed_or_failed_jobs.append(host)
@@ -101,7 +97,8 @@ class Status:
         #   - less useful now that it's just a len call vs the internal value from above?
         print(f"hosts checked ({len(hosts_checked)}): {hosts_checked}")
         print(
-            f"hosts_with_non_completed_or_failed_jobs ({len(hosts_with_non_completed_or_failed_jobs)}): {hosts_with_non_completed_or_failed_jobs}"
+            f"hosts_with_non_completed_or_failed_jobs ({len(hosts_with_non_completed_or_failed_jobs)}): "
+            f"{hosts_with_non_completed_or_failed_jobs}"
         )
 
         # return hosts not idle

--- a/worker_health/worker_health/status.py
+++ b/worker_health/worker_health/status.py
@@ -80,6 +80,25 @@ class Status:
                 try:
                     t_status = status_blob["status"]["state"]
                 except KeyError:
+                    # TODO: do additional checking if problems occur with this...
+                    #   example response that we are catching here:
+                    #
+                    #      {'code': 'ResourceNotFound',
+                    #       'message': '`NpY_UNDIRAW8Jaix-kc-SA` does not correspond to a task that '
+                    #                  'exists.\n'
+                    #                  'Are you sure this task exists?\n'
+                    #                  '\n'
+                    #                  '---\n'
+                    #                  '\n'
+                    #                  '* method:     status\n'
+                    #                  '* errorCode:  ResourceNotFound\n'
+                    #                  '* statusCode: 404\n'
+                    #                  '* time:       2023-06-28T19:39:09.337Z',
+                    #       'requestInfo': {'method': 'status',
+                    #                       'params': {'taskId': 'NpY_UNDIRAW8Jaix-kc-SA'},
+                    #                       'payload': {},
+                    #                       'time': '2023-06-28T19:39:09.337Z'}}
+
                     # print(f"{task_id}: no task[status][state] assuming task is not running.")
                     continue
                 if t_status != "completed" and t_status != "failed" and t_status != "exception":


### PR DESCRIPTION
safe_runner (and unsafe_runner): If tasks have expired, don't explode when ensuring that the host is idle.

also:
- fix line lengths