### PR TITLE
safe_runner: better error handling

### DIFF
--- a/worker_health/worker_health/quarantine.py
+++ b/worker_health/worker_health/quarantine.py
@@ -36,7 +36,9 @@ class Quarantine:
         # try to detect worker group
         wgs = self.get_worker_groups(provisioner=provisioner_id, worker_type=worker_type)
         if len(wgs) > 1:
-            raise Exception("can't guess workerGroup, multiple present. " "support not implemented yet.")
+            raise Exception("can't guess workerGroup, multiple present. support not implemented yet.")
+        if len(wgs) == 0:
+            raise Exception(f"couldn't find a matching workerType ('{worker_type}')!")
         worker_group = wgs[0]
 
         for a_host in host_arr:


### PR DESCRIPTION
rcurran noticed this when running:

```
state file (resumed): /Users/rcurran/Scratch/Safe_Runner/runner_state.toml
run options:
  hosts: 1 total, 0 to skip, 0 skipped, 0 successful, 0 failed, 1 remaining
    remaining: macmini-r8-266
    fqdn_postfix: test.releng.mdc1.mozilla.com
    TC provisioner: releng-hardware
    TC workerType: gecko_t_osx_1015_r8
  command: cd ~/Scratch/ronin_update_gw/ronin_puppet && bolt plan run deploy::apply_no_verify -t SR_HOST.test.releng.mdc1.mozilla.com noop=false -v

Does this look correct? Type 'yes' to proceed: yes

2023-10-03 13:10:08: removed 0 host(s) due to skip list
2023-10-03 13:10:08: pre-quarantine: adding to quarantine: ['macmini-r8-266']
|⚠︎                                       | (!) 0/1 [0%] in 0.2s 
Traceback (most recent call last):
  File "/Users/rcurran/Scratch/android-tools/worker_health/./safe_runner.py", line 74, in <module>
    runner.main(args, safe_mode=True)
  File "/Users/rcurran/Scratch/android-tools/worker_health/worker_health/runner.py", line 655, in main
    sr.q.quarantine(sr.provisioner, sr.worker_type, [pqh], verbose=False)
  File "/Users/rcurran/Scratch/android-tools/worker_health/worker_health/quarantine.py", line 47, in quarantine
    worker_group = wgs[0]
                   ~~~^^^
IndexError: list index out of range
```

I think the error was due to an invalid workerType. The code now detects if no match is found and raises an exception.