### PR TITLE
worker-health: slack alert scheduled restarts

### DIFF
--- a/worker_health/service/slack_alert.service
+++ b/worker_health/service/slack_alert.service
@@ -7,6 +7,8 @@ Documentation=https://github.com/mozilla-platform-ops/android-tools/tree/master/
 Type=simple
 ExecStart=/home/bitbar/.local/bin/pipenv run ./slack_alert.py
 Restart=always
+# address hanging, restart every 4h
+RuntimeMaxSec=4h
 WorkingDirectory=/home/bitbar/android-tools/worker_health
 User=bitbar
 


### PR DESCRIPTION
I've noticed that the slack alert service has started hanging. In lieu of debugging, just restart every few hours for now.

Applied on devicepool0. Testing for a bit.