### PR TITLE
quarantine: fix bug with arg handling

### DIFF
--- a/worker_health/quarantine_tool.py
+++ b/worker_health/quarantine_tool.py
@@ -39,18 +39,18 @@ if __name__ == "__main__":
     # sys.exit(1)
 
     if args.action == "quarantine":
-        if args.action_options is None:
+        if args.hosts is None:
             parser.error("you must specify a comma-separated string of hosts")
-        host_arr = args.action_options.split(",")
+        host_arr = args.hosts.split(",")
         q = quarantine.Quarantine()
         if args.reason:
             q.quarantine(args.provisioner, args.worker_type, host_arr, reason=args.reason)
         else:
             q.quarantine(args.provisioner, args.worker_type, host_arr)
     elif args.action == "lift":
-        if args.action_options is None:
+        if args.hosts is None:
             parser.error("you must specify a comma-separated string of hosts")
-        host_arr = args.action_options.split(",")
+        host_arr = args.hosts.split(",")
         q = quarantine.Quarantine()
         if args.reason:
             q.lift_quarantine(args.provisioner, args.worker_type, host_arr, reason=args.reason)


### PR DESCRIPTION
Error observed:

```bash
(worker_health) powderdry  worker_health git:(master) ✗  ➜  ./quarantine_tool.py releng-hardware gecko-t-osx-1015-r8 quarantine -r "Screencap bug" macmini-r8-30
Traceback (most recent call last):
  File "/Users/aerickson/git/android-tools/worker_health/./quarantine_tool.py", line 42, in <module>
    if args.action_options is None:
       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'action_options'
```