### PR TITLE
runners: v2.0

### DIFF
--- a/worker_health/README.md
+++ b/worker_health/README.md
@@ -90,16 +90,10 @@ Potential issues:
 # for options
 ./safe_runner.py -h
 
-# start option 1: specify all options on the command line
-# command argument substitutions:
-#   'SR_HOST': replaced with the current host
-#   'SR_FQDN': replaced with the fqdn_prefix CLI argument
-./safe_runner.py --talk releng-hardware gecko-t-osx-1015-r8 macmini-r8-22,macmini-r8-23,macmini-r8-24 \
-  "cd ~/git/ronin_puppet && bolt plan run deploy::apply_no_verify -t SR_HOST.SR_FQDN noop=false -v"
-
-# start option 2: create an empty state file, populate, and resume
+# basic usage
 ./safe_runner.py -r sr_state_dir_xyz
-vi sr_state_dir_xyz/runner_state.toml  # and set options
+# edit config and set options
+vi sr_state_dir_xyz/runner_state.toml
 ./safe_runner.py -r sr_state_dir_xyz
 
 # resume from existing state file and set options

--- a/worker_health/safe_runner.py
+++ b/worker_health/safe_runner.py
@@ -7,6 +7,8 @@ import argparse
 
 from worker_health import runner
 
+VERSION = "2.0.0"
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=("runs a command against a set of hosts once " "they are quarantined and not working"),
@@ -14,6 +16,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--resume_dir",
         "-r",
+        required=True,
         metavar="RUN_DIR",
         # custom action that removes the positional args
         action=runner.ResumeAction,
@@ -44,11 +47,12 @@ if __name__ == "__main__":
         help=("don't lift the quarantine after successfully running. " "useful for pre-quarantined bad hosts."),
     )
     # TODO: add argument to do a reboot if run is successful?
-    parser.add_argument(
-        "--fqdn-postfix",
-        "-F",
-        help=("string to append to host (used for ssh check). " f"defaults to '{runner.Runner.default_fqdn_postfix}'."),
-    )
+    # parser.add_argument(
+    #     "--fqdn-postfix",
+    #     "-F",
+    #     help=("string to append to host (used for ssh check). "
+    #            f"defaults to '{runner.Runner.default_fqdn_postfix}'."),
+    # )
     parser.add_argument(
         "--pre_quarantine_additional_host_count",
         "-P",
@@ -62,12 +66,13 @@ if __name__ == "__main__":
         default=runner.Runner.default_pre_quarantine_additional_host_count,
     )
     # positional args
-    parser.add_argument("provisioner", help="e.g. 'releng-hardware' or 'gecko-t'")
-    parser.add_argument("worker_type", help="e.g. 'gecko-t-osx-1015-r8'")
-    parser.add_argument("host_csv", type=runner.csv_strs, help="e.g. 'host1,host2'")
-    parser.add_argument("command", help="command to run locally")
+    # parser.add_argument("provisioner", help="e.g. 'releng-hardware' or 'gecko-t'")
+    # parser.add_argument("worker_type", help="e.g. 'gecko-t-osx-1015-r8'")
+    # parser.add_argument("host_csv", type=runner.csv_strs, help="e.g. 'host1,host2'")
+    # parser.add_argument("command", help="command to run locally")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {VERSION}")
     args = parser.parse_args()
-    args.hosts = args.host_csv
+    # args.hosts = args.host_csv
     # TODO: add as an exposed option?
     args.verbose = True
 

--- a/worker_health/unsafe_runner.py
+++ b/worker_health/unsafe_runner.py
@@ -7,11 +7,14 @@ import argparse
 
 from worker_health import runner
 
+VERSION = "2.0.0"
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=("runs a command against a set of hosts"))
     parser.add_argument(
         "--resume_dir",
         "-r",
+        required=True,
         metavar="RUN_DIR",
         # custom action that removes the positional args
         action=runner.ResumeAction,
@@ -35,18 +38,20 @@ if __name__ == "__main__":
         action="store_true",
         help="reboot the host after command runs successfully.",
     )
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {VERSION}")
     # TODO: add argument to do a reboot if run is successful?
-    parser.add_argument(
-        "--fqdn-postfix",
-        "-F",
-        dest="fqdn_prefix",
-        help=("string to append to host (used for ssh check). " f"defaults to '{runner.Runner.default_fqdn_postfix}'."),
-    )
+    # parser.add_argument(
+    #     "--fqdn-postfix",
+    #     "-F",
+    #     dest="fqdn_prefix",
+    #     help=("string to append to host (used for ssh check). "
+    #           f"defaults to '{runner.Runner.default_fqdn_postfix}'."),
+    # )
     # positional args
-    parser.add_argument("host_csv", type=runner.csv_strs, help="e.g. 'host1,host2'")
-    parser.add_argument("command", help="command to run locally")
+    # parser.add_argument("host_csv", type=runner.csv_strs, help="e.g. 'host1,host2'")
+    # parser.add_argument("command", help="command to run locally")
     args = parser.parse_args()
-    args.hosts = args.host_csv
+    # args.hosts = args.host_csv
     # TODO: add as an exposed option?
     args.verbose = True
     args.dont_lift_quarantine = True

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -791,8 +791,6 @@ def main(args, safe_mode=False):
             try:
                 # if shell_script param, scp script over and run it vs using command
                 if sr.shell_script:
-                    # TODO: a bit chatty to say this on each host... move up a few levels/earlier.
-                    status_print("shell_script present, not using command!")
                     local_path = os.path.join(os.path.dirname(sr.state_file), sr.shell_script)
                     sr.scp_file(host, local_path, "/tmp/runner_script", make_executable=True)
                     sr.safe_run_single_host(
@@ -833,10 +831,7 @@ def main(args, safe_mode=False):
             # TODO: remove need for remaining_hosts... feels gross
             remaining_hosts = list(sr.remaining_hosts)
             status_print(f"completed {host}")
-            status_print(
-                f"hosts remaining ({len(sr.remaining_hosts)}/{host_counts['remaining']}): "
-                f"{', '.join(sr.remaining_hosts)}",
-            )
+            status_print(f"hosts remaining: {len(sr.remaining_hosts)}/{host_counts['remaining']}")
             if args.talk:
                 # say(f"completed {host}.")
                 say(f"{len(sr.remaining_hosts)} hosts remaining.")

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -343,7 +343,7 @@ class Runner:
         # TODO: show error?
         # output = ro.stdout.decode()
         if rc == 0:
-            print(f"transferred file '{file_path}' to '{hostname}:{dest_path}'")
+            status_print(f"transferred file '{file_path}' to '{hostname}:{dest_path}'")
         else:
             raise Exception(f"failed to transfer file '{file_path}' to '{hostname}:{dest_path}'")
 
@@ -758,7 +758,7 @@ def main(args, safe_mode=False):
             try:
                 # TODO: if shell_script param, scp script over and run it vs using command
                 if sr.shell_script:
-                    print("INFO: shell_script present, not using command!")
+                    status_print("shell_script present, not using command!")
                     # scp script over
                     # TODO: path should be relative to toml's path
                     local_path = os.path.join(os.path.dirname(sr.state_file), sr.shell_script)

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -650,8 +650,10 @@ def main(args, safe_mode=False):
         if safe_mode:
             print(f"    TC provisioner: {sr.provisioner}")
             print(f"    TC workerType: {sr.worker_type}")
-        print(f"  command: {sr.command}")
-        print(f"  shell script (causes command to be ignored): {sr.shell_script}")
+        if sr.shell_script:
+            print(f"  shell script (command is ignored): {sr.shell_script}")
+        else:
+            print(f"  command: {sr.command}")
         print("")
     except AttributeError as e:
         print("FATAL: missing config value!?!")

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -299,7 +299,7 @@ class Runner:
         dest_path,
         make_executable=False,
     ):
-        # TODO: check if file exists
+        # check if file exists locally before continuing
         if not os.path.exists(file_path):
             raise Exception(f"file '{file_path}' doesn't exist")
 

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -114,13 +114,9 @@ class Runner:
         self.safe_mode = safe_mode
         # required args
         self.command = command
-        # TODO: needed?
-        # if shell_script == "":
-        #     self.shell_script = None
-        # else:
-        self.shell_script = shell_script
         self.fqdn_postfix = fqdn_prefix.lstrip(".")
         # optional args
+        self.shell_script = shell_script
         self.provisioner = provisioner
         self.worker_type = worker_type
 
@@ -349,7 +345,7 @@ class Runner:
 
     # TODO: have a multi-host with smarter sequencing...
     #   - for large groups of hosts, quarantine several at a time?
-    # TODO: mention what's in the script (if used)
+    # TODO: mention what's in the script (if used) in the output file
     #   - problem: this command doesn't know if we're using a script or not
     def safe_run_single_host(
         self,

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -4,7 +4,6 @@
 # - if you need to quarantine hosts, use safe_runner (this is not safe)
 
 import argparse
-import copy
 import datetime
 import os
 import random
@@ -186,6 +185,7 @@ class Runner:
             # write empty file
             # TODO: verify user wants this
             print("no state file found in directory, creating empty file and exiting...")
+            # TODO: move this code to write_initial_toml() and call it here
             with open(resume_file, "w") as f:
                 f.write("# runner_state.toml \n")
                 f.write("# \n")
@@ -286,23 +286,23 @@ class Runner:
         result_obj["failed"] = len(failed_hosts)
         return result_obj
 
-    def write_initial_toml(self):
-        # populate data
-        data = copy.deepcopy(Runner.empty_config_dict)
-        # config
-        data["config"]["provisioner"] = self.provisioner
-        data["config"]["worker_type"] = self.worker_type
-        data["config"]["command"] = self.command
-        data["config"]["fqdn_prefix"] = self.fqdn_postfix
-        data["config"]["hosts_to_skip"] = self.hosts_to_skip
-        # state
-        data["state"]["remaining_hosts"] = self.remaining_hosts
-        # not writing remaining
+    # def write_initial_toml(self):
+    #     # populate data
+    #     data = copy.deepcopy(Runner.empty_config_dict)
+    #     # config
+    #     data["config"]["provisioner"] = self.provisioner
+    #     data["config"]["worker_type"] = self.worker_type
+    #     data["config"]["command"] = self.command
+    #     data["config"]["fqdn_prefix"] = self.fqdn_postfix
+    #     data["config"]["hosts_to_skip"] = self.hosts_to_skip
+    #     # state
+    #     data["state"]["remaining_hosts"] = self.remaining_hosts
+    #     # not writing remaining
 
-        utils.mkdir_p(os.path.dirname(self.state_file))
-        with open(self.state_file, "w") as f:
-            # TODO: write a comment with info about substitution variables, etc
-            tomlkit.dump(data, f)
+    #     utils.mkdir_p(os.path.dirname(self.state_file))
+    #     with open(self.state_file, "w") as f:
+    #         # TODO: write a comment with info about substitution variables, etc
+    #         tomlkit.dump(data, f)
 
     # loads existing state file first, so we can preserve comments
     def checkpoint_toml(self):
@@ -699,9 +699,10 @@ def main(args, safe_mode=False):
     # TODO: ideally this would just be when we're converging until done
     signal.signal(signal.SIGINT, handler)
 
+    # TODO: is this ever hit?
     # for fresh runs, write toml
-    if not args.resume_dir:
-        sr.write_initial_toml()
+    # if not args.resume_dir:
+    #     sr.write_initial_toml()
 
     # TODO: eventually use this as outer code for safe_run_multi_host
     # TODO: make a more-intelligent multi-host version...

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -208,7 +208,10 @@ class Runner:
         i.skipped_hosts = data["state"]["skipped_hosts"]
         i.failed_hosts = data["state"]["failed_hosts"]
         i.hosts_to_skip = data["config"]["hosts_to_skip"]
-        i.shell_script = data["config"]["shell_script"]
+        if "shell_script" in data["config"]:
+            i.shell_script = data["config"]["shell_script"]
+        else:
+            i.shell_script = None
         i.run_dir = resume_dir
         i.state_file = f"{resume_dir}/{Runner.state_file_name}"
         # create utility instances
@@ -644,6 +647,7 @@ def main(args, safe_mode=False):
             print(f"    TC provisioner: {sr.provisioner}")
             print(f"    TC workerType: {sr.worker_type}")
         print(f"  command: {sr.command}")
+        print(f"  shell script (causes command to be ignored): {sr.shell_script}")
         print("")
     except AttributeError as e:
         print("FATAL: missing config value!?!")

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -74,6 +74,28 @@ def preexec_function():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
+def tomlkit_to_popo(d):
+    try:
+        result = getattr(d, "value")
+    except AttributeError:
+        result = d
+
+    if isinstance(result, list):
+        result = [tomlkit_to_popo(x) for x in result]
+    elif isinstance(result, dict):
+        result = {tomlkit_to_popo(key): tomlkit_to_popo(val) for key, val in result.items()}
+    elif isinstance(result, tomlkit.items.Integer):
+        result = int(result)
+    elif isinstance(result, tomlkit.items.Float):
+        result = float(result)
+    elif isinstance(result, tomlkit.items.String):
+        result = str(result)
+    elif isinstance(result, tomlkit.items.Bool):
+        result = bool(result)
+
+    return result
+
+
 class CommandFailedException(Exception):
     pass
 
@@ -643,9 +665,10 @@ def main(args, safe_mode=False):
         )
         if len(sr.hosts_to_skip) != 0:
             print(f"    skipping: {', '.join(sr.hosts_to_skip)}")
-        print(f"    remaining: {', '.join(sr.remaining_hosts)}")
+        # print(f"    remaining: {', '.join(sr.remaining_hosts)}")
         # TODO: show more detail here (counts of each type)
-        print(f"    fqdn_postfix: {sr.fqdn_postfix}")
+        # print(f"    fqdn_postfix: {sr.fqdn_postfix}")
+        # TODO: show hosts_to_skip?
         # TODO: mention talk, reboot, pre-quarantine count
         if safe_mode:
             print(f"    TC provisioner: {sr.provisioner}")

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -85,10 +85,10 @@ class Runner:
     # TODO: use tomlkit tables so formatting is nice for empty lists?
     empty_config_dict = {
         "config": {
-            "command": "ssh SR_HOST.SR_FQDN",
+            "command": "ssh -o PasswordAuthentication=no SR_HOST uptime",
             "shell_script": "",
             "hosts_to_skip": [],
-            "fqdn_prefix": "",
+            "fqdn_prefix": "",  # TODO: get rid of this, default should be fqdns
             "provisioner": "",
             "worker_type": "",
         },
@@ -103,7 +103,7 @@ class Runner:
     def __init__(
         self,
         hosts=[],
-        command="ssh SR_HOST.SR_FQDN",
+        command="ssh -o PasswordAuthentication=no SR_HOST uptime",
         shell_script=None,
         fqdn_prefix=default_fqdn_postfix,
         safe_mode=False,

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -352,6 +352,8 @@ class Runner:
 
     # TODO: have a multi-host with smarter sequencing...
     #   - for large groups of hosts, quarantine several at a time?
+    # TODO: mention what's in the script (if used)
+    #   - problem: this command doesn't know if we're using a script or not
     def safe_run_single_host(
         self,
         hostname,
@@ -760,18 +762,13 @@ def main(args, safe_mode=False):
             if args.talk:
                 say(f"starting {host}")
             try:
-                # TODO: if shell_script param, scp script over and run it vs using command
+                # if shell_script param, scp script over and run it vs using command
                 if sr.shell_script:
                     status_print("shell_script present, not using command!")
-                    # scp script over
-                    # TODO: path should be relative to toml's path
                     local_path = os.path.join(os.path.dirname(sr.state_file), sr.shell_script)
                     sr.scp_file(host, local_path, "/tmp/runner_script", make_executable=True)
-                    # TODO: chmod 755 remotely or do locally
                     sr.safe_run_single_host(
                         host,
-                        # sr.command, ## use real value for now, but override eventually
-                        # with "/tmp/runner_script",
                         'ssh -o PasswordAuthentication=no SR_HOST.SR_FQDN bash -c -l "/tmp/runner_script"',
                         talk=args.talk,
                         reboot_host=args.reboot_host,

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -305,6 +305,7 @@ class Runner:
 
         host_fqdn = get_fully_qualified_hostname(hostname, self.fqdn_postfix)
 
+        # TODO: ideally we'd only do this once per hosts... this is duplicated in safe_run_single_host
         cmd = f"ssh-keygen -R {host_fqdn}"
         subprocess.run(
             cmd,
@@ -326,14 +327,10 @@ class Runner:
         custom_cmd_temp = command.replace("SR_HOST", hostname)
         custom_cmd = custom_cmd_temp.replace("SR_FQDN", self.fqdn_postfix)
 
-        # print(f"command is: {custom_cmd}")
-
         if make_executable:
             # chmod locally
             os.chmod(file_path, 0o755)
 
-        # split_custom_cmd = ["/bin/bash", "-l", "-c", custom_cmd]
-        # ssh -o PasswordAuthentication=no SR_HOST.SR_FQDN
         split_custom_cmd = custom_cmd.split(" ")
         ro = subprocess.run(
             split_custom_cmd,

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -80,7 +80,7 @@ class CommandFailedException(Exception):
 
 class Runner:
     default_pre_quarantine_additional_host_count = 5
-    default_fqdn_postfix = "test.releng.mdc1.mozilla.com"
+    # default_fqdn_postfix = "test.releng.mdc1.mozilla.com"
     state_file_name = "runner_state.toml"
     # TODO: use tomlkit tables so formatting is nice for empty lists?
     empty_config_dict = {
@@ -105,7 +105,7 @@ class Runner:
         hosts=[],
         command="ssh -o PasswordAuthentication=no SR_HOST uptime",
         shell_script=None,
-        fqdn_prefix=default_fqdn_postfix,
+        fqdn_prefix=None,
         safe_mode=False,
         provisioner=None,
         worker_type=None,

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -757,6 +757,7 @@ def main(args, safe_mode=False):
             try:
                 # if shell_script param, scp script over and run it vs using command
                 if sr.shell_script:
+                    # TODO: a bit chatty to say this on each host... move up a few levels/earlier.
                     status_print("shell_script present, not using command!")
                     local_path = os.path.join(os.path.dirname(sr.state_file), sr.shell_script)
                     sr.scp_file(host, local_path, "/tmp/runner_script", make_executable=True)

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -80,7 +80,7 @@ class CommandFailedException(Exception):
 
 class Runner:
     default_pre_quarantine_additional_host_count = 5
-    # default_fqdn_postfix = "test.releng.mdc1.mozilla.com"
+    default_fqdn_postfix = ""
     state_file_name = "runner_state.toml"
     # TODO: use tomlkit tables so formatting is nice for empty lists?
     empty_config_dict = {
@@ -165,6 +165,14 @@ class Runner:
             # TODO: verify user wants this
             print("no state file found in directory, creating empty file and exiting...")
             with open(resume_file, "w") as f:
+                f.write("# runner_state.toml \n")
+                f.write("# \n")
+                f.write("# - if config.shell_script is present, config.command is ignored \n")
+                f.write("#   - config.shell_script holds the path to the script, relative to this state file \n")
+                f.write("# - for config.command, SR_HOST and SR_FQDN are replaced with the appropriate values \n")
+                f.write("# - provisioner and wrorker_type are only used in safe_runner \n")
+                f.write("# \n")
+                f.write("\n")
                 tomlkit.dump(cls.empty_config_dict, f)
             sys.exit(0)
 
@@ -271,6 +279,7 @@ class Runner:
 
         utils.mkdir_p(os.path.dirname(self.state_file))
         with open(self.state_file, "w") as f:
+            # TODO: write a comment with info about substitution variables, etc
             tomlkit.dump(data, f)
 
     # loads existing state file first, so we can preserve comments

--- a/worker_health/worker_health/runner.py
+++ b/worker_health/worker_health/runner.py
@@ -777,12 +777,16 @@ def main(args, safe_mode=False):
                         break
                 if exit_while:
                     break
-                if terminate > 0:
-                    status_print("graceful exiting...")
-                    sys.exit(0)
                 sleep_time = 60
                 status_print(f"no ssh-able hosts found. sleeping {sleep_time}s...")
-                time.sleep(sleep_time)
+                sleep_time_left = sleep_time
+                while sleep_time_left > 1:
+                    if terminate > 0:
+                        status_print("graceful exiting...")
+                        sys.exit(0)
+                    time.sleep(1)
+                    sleep_time_left -= 1
+
             # print(" found.", flush=True)
             # bar.unpause()
 


### PR DESCRIPTION
### runners (safe and unsafe) v2.0

features:
- no more config on the command line, all done via state file
  - `command` and `host_csv` are not taken on CLI   
  - resume_dir (`-r`) is now a required argument
- shell scripts can be used (vs specifying the command in the state file)
  - background: It's painful cramming everything you want to run into a single line bash script. 
  - solution: Let safe_runner/unsafe_runner use a script file (specified relative to the resume directory).
- simplified startup output
  - doesn't print remaining hosts (only count)
  - doesn't show fqdn
- simplified running output
  - don't show the full list of remaining hosts (just count)