### PR TITLE
slack report: fix logic that was including quarantined hosts

### DIFF
--- a/worker_health/missing_workers.py
+++ b/worker_health/missing_workers.py
@@ -46,12 +46,15 @@ def main():
     wh = health.Health(args.log_level)
 
     # TESTING
-    # output = wh.get_jsonc("https://queue.taskcluster.net/v1/provisioners/proj-autophone/worker-types/gecko-t-ap-unit-p2/workers?limit=50")
+    # output = wh.get_jsonc("https://queue.taskcluster.net/v1/provisioners/"
+    #       "proj-autophone/worker-types/gecko-t-ap-unit-p2/workers?limit=50")
     # wh.pp.pprint(output)
     # sys.exit(0)
 
-    wh.show_missing_workers_report(
-        show_all=args.all, time_limit=args.time_limit, verbosity=args.log_level
+    wh.missing_workers_show_missing_workers_report(
+        show_all=args.all,
+        time_limit=args.time_limit,
+        verbosity=args.log_level,
     )
 
 

--- a/worker_health/slack_alert.py
+++ b/worker_health/slack_alert.py
@@ -84,6 +84,7 @@ currently_alerting = false
             # bold workers with high confidence (devicepool showing as bad)
             worker_string = "["
             for worker in report_data["union"]:
+                # bold the device if it's offline in the devicepool api
                 if worker in report_data["devicepool"]:
                     worker_string += "*%s*, " % worker
                 else:

--- a/worker_health/worker_health/fitness.py
+++ b/worker_health/worker_health/fitness.py
@@ -3,6 +3,7 @@ import json
 import os
 import pprint
 import subprocess
+import sys
 from multiprocessing.pool import ThreadPool
 from time import time as timer
 
@@ -413,7 +414,7 @@ class Fitness:
             elif isinstance(value, int):
                 result_string += "{:2d}".format(value)
             elif isinstance(value, list):
-                result_string += pprint.pformat(value)
+                result_string += pprint.pformat(value, width=sys.maxsize)
             elif isinstance(value, float):
                 # the only float is success rate
                 result_string += utils.graph_percentage(value)

--- a/worker_health/worker_health/health.py
+++ b/worker_health/worker_health/health.py
@@ -691,10 +691,14 @@ class Health:
             print(
                 output_format
                 % (
-                    "tc 2 (%s)" % len(mw2),
+                    "tc2 (%s)" % len(mw2),
                     mw2,
                 ),
             )
+
+            # tc + tc2 union
+            merged = self.make_list_unique(mw2 + missing_workers_flattened)
+            print(output_format % ("tc+tc2 (%s)" % len(merged), merged))
 
             # show quarantined
             if self.quarantined_workers:

--- a/worker_health/worker_health/health.py
+++ b/worker_health/worker_health/health.py
@@ -670,6 +670,8 @@ class Health:
         if time_limit:
             output_format = "%-16s %s"
 
+            # TODO: explain tc vs tc2
+
             # exclude quarantined as we mention them specifically later
             missing_workers = self.calculate_missing_workers_from_tc(time_limit, exclude_quarantined=True)
             missing_workers_flattened = self.flatten_list(missing_workers.values())
@@ -681,6 +683,7 @@ class Health:
                 ),
             )
 
+            # tc2
             mw2 = self.get_tc_missing_workers()
             print(
                 output_format
@@ -690,6 +693,7 @@ class Health:
                 ),
             )
 
+            # show quarantined
             if self.quarantined_workers:
                 print(
                     output_format
@@ -757,7 +761,8 @@ class Health:
             return result_dict
 
     def influx_report(self, time_limit=None, verbosity=0):
-        problem_workers = self.get_problem_workers2(time_limit=time_limit, exclude_quarantined=False)
+        # include quarantined
+        problem_workers = self.influx_report_get_problem_workers2(time_limit=time_limit, exclude_quarantined=False)
 
         logger.info("generating influx log lines for problem workers...")
         self.influx_log_lines_to_send.extend(self.gen_influx_mw_lines(problem_workers))

--- a/worker_health/worker_health/health.py
+++ b/worker_health/worker_health/health.py
@@ -373,7 +373,7 @@ class Health:
     #   - the output from self.calculate_missing_workers_from_tc misses these devices unless there are jobs in the queue
     #
     # new simpler function that doesn't worry about tardy
-    def get_tc_missing_workers(self, verbose=False):
+    def get_tc_missing_workers(self, exclude_quarantined=False, verbose=False):
         missing_workers = set()
         expected_workers = self.get_devicepool_config_workers()
         for worker in expected_workers:
@@ -407,6 +407,9 @@ class Health:
                         print("boo adding %s 2" % worker)
                     missing_workers.add(worker)
                     continue
+
+        if exclude_quarantined:
+            missing_workers = set(missing_workers) - set(self.quarantined_workers)
 
         # dedupe and return list
         return sorted(list(set(missing_workers)))
@@ -684,7 +687,7 @@ class Health:
             )
 
             # tc2
-            mw2 = self.get_tc_missing_workers()
+            mw2 = self.get_tc_missing_workers(exclude_quarantined=True)
             print(
                 output_format
                 % (

--- a/worker_health/worker_health/health.py
+++ b/worker_health/worker_health/health.py
@@ -636,7 +636,7 @@ class Health:
         return set(return_arr)
 
     # returns a dict
-    def get_problem_workers2(self, time_limit=None, verbosity=0, exclude_quarantined=False):
+    def influx_report_get_problem_workers2(self, time_limit=None, verbosity=0, exclude_quarantined=False):
         # TODO: stop calling gather_data in processing/calculation code
         # - only call when necessary, push up to higher level
         self.gather_data()
@@ -655,7 +655,7 @@ class Health:
         # use flatten_dict if needed in list
         return merged2
 
-    def show_missing_workers_report(self, show_all=False, time_limit=None, verbosity=0):
+    def missing_workers_show_missing_workers_report(self, show_all=False, time_limit=None, verbosity=0):
         self.gather_data()
 
         if verbosity:

--- a/worker_health/worker_health/health.py
+++ b/worker_health/worker_health/health.py
@@ -414,6 +414,7 @@ class Health:
     # TODO: unit test this
     # rename/rework to detect_tardy()
     def calculate_missing_workers_from_tc(self, limit, exclude_quarantined=False):
+        include_quarantined = not exclude_quarantined
         # TODO: get rid of intermittents
         # store a file with last_seen_online for each host
         #   - if not offline, remove
@@ -436,8 +437,13 @@ class Health:
                 more_workers_than_jobs = True
 
             for worker in self.devicepool_queues_and_workers[queue]:
-                if not exclude_quarantined and worker in self.quarantined_workers:
+                # adds quarantined workers to problem hosts if exclude_quarantined=False
+                if include_quarantined and worker in self.quarantined_workers:
                     mw2[queue].append(worker)
+                    continue
+
+                # skip quarantined hosts if exclude_quarantined
+                if exclude_quarantined and worker in self.quarantined_workers:
                     continue
 
                 if worker in self.tc_current_worker_last_started:


### PR DESCRIPTION
Quarantined hosts are currently being indicated as `problem hosts` in the slack report. They're problems for us (still included in the influx logger), but let's not nag Bitbar about them.

Also:
- tweak fitness.py formatting
- missing workers: tweak output