### PR TITLE
refactoring and quarantined host eval tool

### DIFF
--- a/worker_health/fitness_check.py
+++ b/worker_health/fitness_check.py
@@ -30,16 +30,14 @@ if __name__ == "__main__":
         "--alert-percent",
         default=fitness.ALERT_PERCENT,
         type=float,
-        help="percentage of successful jobs to alert at. 0 to 1, defaults to %s."
-        % fitness.ALERT_PERCENT,
+        help="percentage of successful jobs to alert at. 0 to 1, defaults to %s." % fitness.ALERT_PERCENT,
     )
     parser.add_argument(
         "-t",
         "--alert-time",
         default=fitness.ALERT_TIME,
         type=int,
-        help="alert if a worker hasn't worked in this many minutes, defaults to %s."
-        % fitness.ALERT_TIME,
+        help="alert if a worker hasn't worked in this many minutes, defaults to %s." % fitness.ALERT_TIME,
     )
     parser.add_argument(
         "-o",
@@ -114,4 +112,4 @@ if __name__ == "__main__":
     )
     # TODO: just pass args?
     f.args = args
-    f.main(args.provisioner, arg_worker_type, arg_worker_id)
+    f.main(arg_worker_type, arg_worker_id)

--- a/worker_health/quarantine_eval.py
+++ b/worker_health/quarantine_eval.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Idea: We have X hosts in quarantine. Let them run one job and then see if
+# they're better, if not quarantine them again.
+#
+# - Detects if there are pending jobs and only runs then?
+# - Maybe always put them back in quarantine after one job and present a report?
+
+# v0: single host
+# - take single host as input
+# - check that there are jobs to run
+# - record current state of host
+# - remove from quarantine
+# - wait for job to start
+# - place back in quarantine (done immediately so only single job runs)
+# - loop until the job is done
+# - record current state of host
+# - record sucess/failure for host
+
+# v1: multiple hosts
+# step 1: take list of quarantined hosts
+# step 2: repeat v0 over all hosts
+# step 3: show report
+
+# v2: advanced
+# step 1: gather quarantined hosts

--- a/worker_health/worker_health/fitness.py
+++ b/worker_health/worker_health/fitness.py
@@ -111,7 +111,7 @@ class Fitness:
         result_object["worker_id"] = worker_id
         return result_object
 
-    def main(self, provisioner, worker_type, worker_id):
+    def main(self, worker_type, worker_id):
         # TODO: show when worker last started a task (taskStarted in TC)
         # - aws metal nodes has quarantined nodes that have been deleted that never drop off from worker-data
 
@@ -135,7 +135,7 @@ class Fitness:
                 worker_types = [worker_type]
             # provisioner mode
             else:
-                worker_types_result = self.get_worker_types(provisioner)
+                worker_types_result = self.get_worker_types(self.provisioner)
                 worker_types = []
                 if "workerTypes" in worker_types_result:
                     for provisioner in worker_types_result["workerTypes"]:

--- a/worker_health/worker_health/fitness.py
+++ b/worker_health/worker_health/fitness.py
@@ -138,8 +138,8 @@ class Fitness:
                 worker_types_result = self.get_worker_types(self.provisioner)
                 worker_types = []
                 if "workerTypes" in worker_types_result:
-                    for provisioner in worker_types_result["workerTypes"]:
-                        worker_type = provisioner["workerType"]
+                    for prov in worker_types_result["workerTypes"]:
+                        worker_type = prov["workerType"]
                         worker_types.append(worker_type)
                     # print(worker_types)
                 else:


### PR DESCRIPTION
Idea: We have X hosts in quarantine. Let them run one job and then see if they're better, if not quarantine them again.
- Detects if there are pending jobs and only runs then?
- Maybe always put them back in quarantine after one job and present a report?